### PR TITLE
Open decryption app on detection of a PGP encrypted NDEF record

### DIFF
--- a/Lexov/Lexov.Android/Lexov.Android.csproj
+++ b/Lexov/Lexov.Android/Lexov.Android.csproj
@@ -76,6 +76,7 @@
     <Compile Include="Resources\Resource.designer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utilities\BaseDependencyImplementation.cs" />
+    <Compile Include="Utilities\OpenAppAndroid.cs" />
     <Compile Include="Utilities\OrientationHandler.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Lexov/Lexov.Android/MainActivity.cs
+++ b/Lexov/Lexov.Android/MainActivity.cs
@@ -10,6 +10,7 @@ using Android.Nfc;
 using Poz1.NFCForms.Droid;
 using Android.Content;
 using Poz1.NFCForms.Abstract;
+using Lexov.Droid.Utilities;
 
 namespace Lexov.Droid
 {
@@ -27,6 +28,8 @@ namespace Lexov.Droid
 
             Xamarin.Essentials.Platform.Init(this, savedInstanceState);
             global::Xamarin.Forms.Forms.Init(this, savedInstanceState);
+
+            Xamarin.Forms.DependencyService.Register<OpenAppAndroid>();
 
             NfcManager NfcManager = (NfcManager)Android.App.Application.Context.GetSystemService(Context.NfcService);
             NFCdevice = NfcManager.DefaultAdapter;

--- a/Lexov/Lexov.Android/Utilities/OpenAppAndroid.cs
+++ b/Lexov/Lexov.Android/Utilities/OpenAppAndroid.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using Android.App;
+using Android.Content;
+using Android.OS;
+using Android.Runtime;
+using Android.Views;
+using Android.Widget;
+using Lexov.Droid.Utilities;
+using Lexov.Utilities;
+using Xamarin.Forms;
+
+[assembly: Xamarin.Forms.Dependency(typeof(OpenAppAndroid))]
+namespace Lexov.Droid.Utilities
+{
+    public class OpenAppAndroid : Activity, IOpenApp
+    {
+        public OpenAppAndroid() { }
+
+        [Obsolete]
+        public void OpenExternalApp()
+        {
+            Intent intent = Android.App.Application.Context.PackageManager.GetLaunchIntentForPackage("org.sufficientlysecure.keychain");
+
+            if(intent != null)
+            {
+                intent.AddFlags(ActivityFlags.NewTask);
+                Forms.Context.StartActivity(intent);
+            }
+            else
+            {
+                intent = new Intent(Intent.ActionView);
+                intent.AddFlags(ActivityFlags.NewTask);
+                intent.SetData(Android.Net.Uri.Parse("https://f-droid.org/en/packages/org.sufficientlysecure.keychain/"));
+                Forms.Context.StartActivity(intent);
+            }
+        }
+    }
+}

--- a/Lexov/Lexov.Android/Utilities/OpenAppAndroid.cs
+++ b/Lexov/Lexov.Android/Utilities/OpenAppAndroid.cs
@@ -23,7 +23,7 @@ namespace Lexov.Droid.Utilities
         [Obsolete]
         public void OpenExternalApp()
         {
-            Intent intent = Android.App.Application.Context.PackageManager.GetLaunchIntentForPackage("org.sufficientlysecure.keychain");
+            Intent intent = Android.App.Application.Context.PackageManager.GetLaunchIntentForPackage("org.sufficientlysecure.keychain.debug");
 
             if(intent != null)
             {

--- a/Lexov/Lexov/Pages/NDEFRead.xaml.cs
+++ b/Lexov/Lexov/Pages/NDEFRead.xaml.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
+using Xamarin.Essentials;
 
 namespace Lexov.Pages
 {
@@ -24,6 +25,8 @@ namespace Lexov.Pages
         {
             InitializeComponent();
             DependencyService.Get<IOrientationHandler>().ForcePortrait();
+
+            checkEncrypted(NDEFPayload);
 
             ndefPayloadRead = NDEFPayload;
             uxClearButton.Clicked += uxClearButton_Clicked;
@@ -39,6 +42,28 @@ namespace Lexov.Pages
 
             uxNDEFEditor.Text = ndefPayloadRead;
             uxNDEFStack.Children.Add(uxNDEFEditor);
+        }
+
+        async void checkEncrypted(string NDEFPayload)
+        {
+            if (NDEFPayload.Length < 27)
+            {
+                return;
+            }
+
+            else if (!NDEFPayload.Substring(0, 27).Equals("-----BEGIN PGP MESSAGE-----"))
+            {
+                return;
+            }
+
+            else
+            {
+                if(await DisplayAlert("PGP ecrypted payload detected","Attempt decryption in OpenKeychain?", "Yes", "No"))
+                {
+                    await Clipboard.SetTextAsync(NDEFPayload);
+                    DependencyService.Get<Utilities.IOpenApp>().OpenExternalApp();
+                }
+            }
         }
 
         void uxWriteButton_Clicked(object sender, EventArgs e)

--- a/Lexov/Lexov/Utilities/IOpenApp.cs
+++ b/Lexov/Lexov/Utilities/IOpenApp.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Lexov.Utilities
+{
+    public interface IOpenApp
+    {
+        void OpenExternalApp();
+    }
+}


### PR DESCRIPTION
This branch adds the functionality of prompting the user if they want to open the OpenKeychain app on the successful scan of a PGP encrypted NDEF record. It also copies the NDEF record contents the the Android system clipboard for easy decryption in the OpenKeychain app.

Added Items:
- **IOpenApp.cs** interface
- **OpenAppAndroid.cs** interface implementation