### PR TITLE
Lexov now opens as the default NFC application on scan of NDEF record…

### DIFF
--- a/Lexov/Lexov.Android/MainActivity.cs
+++ b/Lexov/Lexov.Android/MainActivity.cs
@@ -15,6 +15,7 @@ using Lexov.Droid.Utilities;
 namespace Lexov.Droid
 {
     [Activity(Label = "Lexov", Icon = "@drawable/SNC", Theme = "@style/MainTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
+    [IntentFilter(new[] { NfcAdapter.ActionNdefDiscovered }, Categories = new[] { Intent.CategoryDefault }, DataMimeType = "text/plain")]
     public class MainActivity : global::Xamarin.Forms.Platform.Android.FormsAppCompatActivity
     {
         public NfcAdapter NFCdevice;

--- a/Lexov/Lexov.Android/Properties/AndroidManifest.xml
+++ b/Lexov/Lexov.Android/Properties/AndroidManifest.xml
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.iotarex.lexov" android:installLocation="auto">
 	<uses-sdk android:minSdkVersion="25" android:targetSdkVersion="29" />
-	<application android:label="Lexov"></application>
+	<application android:label="Lexov">
+  </application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.NFC" />
 	<uses-permission android:name="android.permission.BIND_NFC_SERVICE" />


### PR DESCRIPTION
... for the Android OS when installed. Still need to figure out how to use the triggering scan as the read-in NDEF record.